### PR TITLE
doc: fixed --encrypt-headers parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ And add to the end of ```/etc/postfix/master.cf```:
 
 ```
 gpgmail-pipe    unix    -    n    n    -    -    pipe
-  flags=Rq user=gpgmail argv=/usr/bin/gpgmail-postfix --sign-encrypt --gnupghome /home/gpgmail/.gnupg --encrypt-header --key KEYID --passphrase PASSPHRASE --recipient ${recipient} -oi -f ${sender}
+  flags=Rq user=gpgmail argv=/usr/bin/gpgmail-postfix --sign-encrypt --gnupghome /home/gpgmail/.gnupg --encrypt-headers --key KEYID --passphrase PASSPHRASE --recipient ${recipient} -oi -f ${sender}
 ```


### PR DESCRIPTION
The parameter for `gpgmail-postfix` is called `--encrypt-headers`, not `--encrypt-header`. Failure to configure the parameter correctly in /etc/postfix/master.cf will result in errors, as the misspelled parameter is then ignored by the script and passed through to `sendmail`.