### PR TITLE
fix: handling and quoting of sendmail args

### DIFF
--- a/gpgmail-postfix
+++ b/gpgmail-postfix
@@ -64,7 +64,7 @@ GPGMAIL_encrypt_headers=
 
 RECIPIENT=
 
-SENDMAIL_ARGS=
+SENDMAIL_ARGS=()
 
 while true ; do
     case "$1" in
@@ -84,7 +84,7 @@ while true ; do
         -h|--help) usage ;;
         -v|--version) version ;;
         "") break ;;
-        *) [ -n "$SENDMAIL_ARGS" ] && SENDMAIL_ARGS="${SENDMAIL_ARGS} ${1}" || SENDMAIL_ARGS=$1; shift ;;
+        *) SENDMAIL_ARGS+=("${1}"); shift ;;
     esac
 done
 
@@ -93,5 +93,5 @@ done
 set -o pipefail
 
 #encrypt and resend directly from stdin
-eval ${GPGMAIL} "${GPGMAIL_command}" "${GPGMAIL_encrypt_headers}" "${GPGMAIL_gnupghome}" "${GPGMAIL_key}" "${GPGMAIL_passphrase}" "${RECIPIENT}" | ${SENDMAIL} "${SENDMAIL_ARGS}" "${RECIPIENT}"
+eval ${GPGMAIL} "${GPGMAIL_command}" "${GPGMAIL_encrypt_headers}" "${GPGMAIL_gnupghome}" "${GPGMAIL_key}" "${GPGMAIL_passphrase}" "${RECIPIENT}" | ${SENDMAIL} "${SENDMAIL_ARGS[@]}" "${RECIPIENT}"
 exit $?


### PR DESCRIPTION
This fixes the quoting of the sendmail args in `gpgmail-postfix`.
Sendmail args are now collected using an array and then submitted to sendmail in individual quotes arguments.

Previously the sendmail command line would look like this: `/usr/sbin/sendmail "-oi -f sender@domain.tld" "recipient@domain.tld`. Sendmail would silently drop at least the `-f sender@domain.tld` part, because it's not its own argument. As a result, the `Return-Path` of the processed mail would be incorrect (e.g. `gpgmail@mail.domain.tld` instead of `sender@domain.tld`).

After the change the sendmail command line looks like this: `/usr/sbin/sendmail "-oi" "-f" "sender@domain.tld" "recipient@domain.tld`. 