### PR TITLE
feat: add arg to override gpgmail path

### DIFF
--- a/gpgmail-postfix
+++ b/gpgmail-postfix
@@ -18,7 +18,7 @@
 
 usage() {
     cat << EOF
-usage: gpgmail-postfix (-d|-e|-s|-E) [-H|-S] [-g PATH] [-k KEYID] [-p PASSPHRASE] -r RECIPIENT [SENDMAIL_ARGS]
+usage: gpgmail-postfix (-d|-e|-s|-E) [-H|-S] [-g PATH] [-k KEYID] [-p PASSPHRASE] [--sendmailpath SENDMAIL_PATH] -r RECIPIENT [SENDMAIL_ARGS]
 
 OPTIONS:
     -d / --decrypt                  Decrypt E-mail
@@ -33,6 +33,8 @@ OPTIONS:
     -k / --key KEYID                PGP-key to use
     -p / --passphrase PASSPHRASE    Passphrase for PGP-key
     -r / --recipient RECIPIENT      E-mail recipient
+    
+    --sendmailpath SENDMAIL_PATH    Path to sendmail or other mail sending utility
 
     SENDMAIL_ARGS                   Arguments passed to sendmail
 
@@ -80,6 +82,8 @@ while true ; do
         -k|--key) GPGMAIL_key="--key=${2}" ; shift 2 ;;
         -p|--passphrase) GPGMAIL_passphrase="--passphrase=${2}"; shift 2 ;;
         -r|--recipient) RECIPIENT=$2; shift 2 ;;
+
+        --sendmailpath) SENDMAIL="${2}" ; shift 2 ;;
 
         -h|--help) usage ;;
         -v|--version) version ;;

--- a/gpgmail-postfix
+++ b/gpgmail-postfix
@@ -64,7 +64,7 @@ GPGMAIL_encrypt_headers=
 
 RECIPIENT=
 
-SENDMAIL_ARGS=
+SENDMAIL_ARGS=()
 
 while true ; do
     case "$1" in
@@ -84,7 +84,7 @@ while true ; do
         -h|--help) usage ;;
         -v|--version) version ;;
         "") break ;;
-        *) [ -n "$SENDMAIL_ARGS" ] && SENDMAIL_ARGS="${SENDMAIL_ARGS} ${1}" || SENDMAIL_ARGS=$1; shift ;;
+        *) SENDMAIL_ARGS+=("${1}"); shift ;;
     esac
 done
 
@@ -93,5 +93,5 @@ done
 set -o pipefail
 
 #encrypt and resend directly from stdin
-eval ${GPGMAIL} "${GPGMAIL_command}" "${GPGMAIL_encrypt_headers}" "${GPGMAIL_gnupghome}" "${GPGMAIL_key}" "${GPGMAIL_passphrase}" "${RECIPIENT}" | ${SENDMAIL} "${SENDMAIL_ARGS}" "${RECIPIENT}"
+eval ${GPGMAIL} "${GPGMAIL_command}" "${GPGMAIL_encrypt_headers}" "${GPGMAIL_gnupghome}" "${GPGMAIL_key}" "${GPGMAIL_passphrase}" "${RECIPIENT}" | ${SENDMAIL} "${SENDMAIL_ARGS[@]}" "${RECIPIENT}"
 exit $?

--- a/gpgmail-postfix
+++ b/gpgmail-postfix
@@ -18,7 +18,7 @@
 
 usage() {
     cat << EOF
-usage: gpgmail-postfix (-d|-e|-s|-E) [-H|-S] [-g PATH] [-k KEYID] [-p PASSPHRASE] -r RECIPIENT [SENDMAIL_ARGS]
+usage: gpgmail-postfix (-d|-e|-s|-E) [-H|-S] [-g PATH] [-k KEYID] [-p PASSPHRASE] -r RECIPIENT [--gpgmailpath GPGMAIL_PATH] [SENDMAIL_ARGS]
 
 OPTIONS:
     -d / --decrypt                  Decrypt E-mail
@@ -33,6 +33,8 @@ OPTIONS:
     -k / --key KEYID                PGP-key to use
     -p / --passphrase PASSPHRASE    Passphrase for PGP-key
     -r / --recipient RECIPIENT      E-mail recipient
+    
+    --gpgmailpath GPGMAIL_PATH      Path to gpgmail
 
     SENDMAIL_ARGS                   Arguments passed to sendmail
 
@@ -81,6 +83,8 @@ while true ; do
         -p|--passphrase) GPGMAIL_passphrase="--passphrase=${2}"; shift 2 ;;
         -r|--recipient) RECIPIENT=$2; shift 2 ;;
 
+        --gpgmailpath) GPGMAIL="${2}" ; shift 2 ;;
+        
         -h|--help) usage ;;
         -v|--version) version ;;
         "") break ;;


### PR DESCRIPTION
This adds support for non-standard gpgmail paths (such as /usr/local/bin/gpgmail), which then can be configured on the command line. 

Didn't think of any shortform arg name for `--gpgmailpath`, add as you see fit if you want.