### PR TITLE
fix(gpgmail-postfix): rename forgotten SENDMAIL_ARGS

### DIFF
--- a/gpgmail-postfix
+++ b/gpgmail-postfix
@@ -96,7 +96,7 @@ done
 while [[ $# -gt 0 ]]; do
     case "$1" in
         "") break ;;
-        *) SENDMAIL_ARGS+=("${1}"); shift ;;
+        *) MAILER_ARGS+=("${1}"); shift ;;
     esac
 done
 


### PR DESCRIPTION
rename forgotten SENDMAIL_ARGS to MAILER_ARGS