### PR TITLE
fix(gpgmail): parse mail from bytes instead of string

### DIFF
--- a/gpgmail
+++ b/gpgmail
@@ -32,7 +32,7 @@ import re
 import sys
 
 from argparse import ArgumentParser, FileType, RawTextHelpFormatter
-from email import message_from_string
+from email import message_from_bytes
 from email.message import Message
 from email.mime.base import MIMEBase
 from gnupg import GPG
@@ -128,7 +128,7 @@ def encrypt(
         content_transfer_encoding = mail["Content-Transfer-Encoding"]
 
     if sign_mail and key:
-        pmail = message_from_string(sign(mail, key, passphrase, gnupghome))
+        pmail = message_from_bytes(sign(mail, key, passphrase, gnupghome))
     else:
         pmail = protected_headers_mail(mail)
     gpg = GPG(gnupghome=gnupghome)
@@ -287,9 +287,9 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "MAIL",
-        type=FileType("r", encoding="utf8"),
+        type=FileType("rb"),
         nargs="?",
-        default=sys.stdin,
+        default=sys.stdin.buffer,
         help="E-mail, default from stdin.",
     )
 
@@ -319,7 +319,7 @@ if __name__ == "__main__":
 
     orig_mail = args.MAIL.read()
     try:
-        mail = message_from_string(orig_mail)
+        mail = message_from_bytes(orig_mail)
         if args.decrypt:
             sys.stdout.write(decrypt(mail, args.gnupghome, passphrase=args.passphrase))
         elif args.encrypt or args.sign_encrypt:


### PR DESCRIPTION
Arriving messages might not be properly encoded in utf8 and as a result parsing might fail, since the encoding is hardcoded as utf8. This then results in rejected mail, which is not desired.

This change moves from `message_from_string`  to `message_from_bytes` and lets the `email` module handle any encoding problems that might arrise. This is the same way that zeyple handles parsing of mail: https://github.com/infertux/zeyple/blob/cc125b7b44432542b227887fd7e2701f77fd8ca2/zeyple/zeyple.py#L35

I have not fully tested this change and I'm also not fully aware of the consequences, but it did fix my issue with encrypting mails that were not properly utf8 encoded (headers and/or body content). Maybe you have more insight/knowledge with this?