### PR TITLE
Feat: Add base64-passphrase option

### DIFF
--- a/gpgmail-postfix
+++ b/gpgmail-postfix
@@ -18,7 +18,7 @@
 
 usage() {
     cat << EOF
-usage: gpgmail-postfix (-d|-e|-s|-E) [-H|-S] [-g PATH] [-k KEYID] [-p PASSPHRASE] [-a GPGMAIL_PATH] [-m MAILER_PATH] -r RECIPIENT [MAILER_ARGS]
+usage: gpgmail-postfix (-d|-e|-s|-E) [-H|-S] [-g PATH] [-k KEYID] [-p|-b PASSPHRASE] [-a GPGMAIL_PATH] [-m MAILER_PATH] -r RECIPIENT [MAILER_ARGS]
 
 OPTIONS:
     -d / --decrypt                  Decrypt E-mail
@@ -32,6 +32,7 @@ OPTIONS:
     -g / --gnupghome PATH           Path to gnupg home
     -k / --key KEYID                PGP-key to use
     -p / --passphrase PASSPHRASE    Passphrase for PGP-key
+    -b / --base64-passphrase        Base64 encoded passphrase for PGP-key
     -a / --path GPGMAIL_PATH        Path to gpgmail, defaults to /usr/bin/gpgmail
     -r / --recipient RECIPIENT      E-mail recipient
 
@@ -81,7 +82,8 @@ while [[ $# -gt 0 ]]; do
 
         -g|--gnupghome) GPGMAIL_gnupghome="--gnupghome=${2}"; shift 2 ;;
         -k|--key) GPGMAIL_key="--key=${2}"; shift 2 ;;
-        -p|--passphrase) GPGMAIL_passphrase="--passphrase=${2}"; shift 2 ;;
+        -p|--passphrase) [ -n "$GPGMAIL_passphrase" ] && usage || GPGMAIL_passphrase="--passphrase=${2}"; shift 2 ;;
+        -b|--base64-passphrase) [ -n "$GPGMAIL_passphrase" ] && usage || GPGMAIL_passphrase="--passphrase='$(echo "${2}" | base64 -d -)'"; shift 2 ;;
         -a|--path) GPGMAIL="${2}"; shift 2 ;;
         -r|--recipient) RECIPIENT=$2; shift 2 ;;
 


### PR DESCRIPTION
I have found that Postfix's parsing of arguments in master.cf will not allow for passphrases with spaces, quoted or otherwise.

I thought base64 was probably the simplest way to fix this.

Added a new option and the script will print usage if the variable is already present like the others
